### PR TITLE
Use `mx.io.ImageRecordIter` instead of `mx.image.ImageIter`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Don't, by default, check in our model params.  You can override this by explicitly
+# `git add`'ing params if you want to save them for all eternity.
+*.params
+
+# Don't check in the recordio files
+*.idx
+*.lst
+*.rec
+
+# Don't check in the video frames
+videoFrames/
+videoFrames.zip

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+# By default, build the `run` target
+all: run
+
+# Rule to download zipfile
+videoFrames.zip:
+	curl -L 'https://www.dropbox.com/s/yvkdq5kiait86b9/videoFrames.zip?dl=1' -o $@
+
+# Rule to extract the video frames; touch it to set the proper timestamp
+videoFrames: videoFrames.zip
+	unzip $< -x "__MACOSX/*"
+	touch $@
+
+# From here on out, we'll run python commands within a docker container
+DOCKERIZE = docker run -v $$(pwd):/app -w /app -ti jwfromm/mxa_cpu
+
+# Rule to generate the .lst files
+mk_train.lst: videoFrames
+	$(DOCKERIZE) python3 im2rec.py --list --recursive --num-thread 4 --train-ratio 0.6 --test-ratio 0.2 mk videoFrames
+
+# Rule to generate the .rec files
+mk_train.rec: mk_train.lst
+	$(DOCKERIZE) python3 im2rec.py --num-thread 4 mk videoFrames
+
+# Rule to pop open an interactive IPython shell within the docker container
+shell:
+	$(DOCKERIZE) ipython3
+
+# Rule to run the whole shebang and generate some params!
+run: mk_train.rec
+	$(DOCKERIZE) python3 notHotDog.py
+
+# Rule to cleanup after ourselves.  Purposefully does not delete params.
+clean:
+	rm -f *.idx *.rec *.lst *.zip
+	rm -rf videoFrames

--- a/notHotDog.py
+++ b/notHotDog.py
@@ -14,8 +14,8 @@ from mxnet.test_utils import download
 batch_size = 64
 ctx = [mx.cpu()]
 
-train_iter = mx.image.ImageIter(batch_size=batch_size,data_shape=(3,270,270),label_width=1,path_imgrec='mk_train.rec',shuffle=False,part_index=0,num_parts=1)
-val_iter = mx.image.ImageIter(batch_size=batch_size,data_shape=(3,270,270),label_width=1,path_imgrec='mk_val.rec',shuffle=False,part_index=0,num_parts=1)
+train_iter = mx.io.ImageRecordIter(batch_size=batch_size, data_shape=(3,270,270), label_width=1, path_imgrec='mk_train.rec', shuffle=True)
+val_iter = mx.io.ImageRecordIter(batch_size=batch_size, data_shape=(3,270,270), label_width=1, path_imgrec='mk_val.rec', shuffle=False)
 
 # train_iter.reset()
 # for data in train_iter:


### PR DESCRIPTION
So reading the [kinda buggy documentation](https://mxnet.incubator.apache.org/tutorials/basic/data.html#image-io) (in their defense, buggy documentation is way better than no documentation!) it states there are four ways of loading image data:

> 1. Using `mx.image.imdecode` to load raw image files.
> 2. Using `mx.img.ImageIter` implemented in Python which is very flexible to customization. It can read from .rec(RecordIO) files and raw image files.
> 3. Using `mx.io.ImageRecordIter` implemented on the MXNet backend in C++. This is less flexible to customization but provides various language bindings.
> 4. Creating a Custom iterator inheriting `mx.io.DataIter`

You've been using (2).  This PR switches it over to (3).  Why?  Because, looking at [the docs for `mx.io.ImageRecordIter`](https://mxnet.incubator.apache.org/api/python/io/io.html#mxnet.io.ImageRecordIter), we see that this class has a `round_batch` parameter.  Hallelujah.

With that tiny change made, you can train for multiple epochs, and indeed, your aptly-named "dognet" gets 100% testing accuracy after, like, 3 epochs.  So that's kind of scary.  :D

I also added a `Makefile` as a demo of yet another neat little tool that you can learn to set up a series of steps that depend on eachother, to download/extract the data, build the `.rec` files, and train the model inside the `jwfromm/mxa_cpu` container.  So you should be able to, on a new computer, just run `make` and it'll go from zero to sixty in one go.

Note; `Makefile`s are finnicky beasts, the best way to learn how to use them is to adapt them from other examples at first.  To quote [Jeff Bezanson](https://github.com/JeffBezanson), "`make` is the worst possibly solution to the build dependency problem, except for all of the alternatives".